### PR TITLE
Create a TTL index so that expired data is deleted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -275,7 +275,11 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
                 return callback(err);
             }
 
-            return callback();
+            var ttlSec = Math.max(1, Math.floor(ttl / 1000));
+            collection.ensureIndex({ 'stored': 1 }, { expireAfterSeconds: ttlSec }, function (err) {
+
+                return callback(err);
+            });
         });
     });
 };


### PR DESCRIPTION
At the moment expired data isn't deleted and builds up in the database. This creates a [TTL index](http://docs.mongodb.org/manual/tutorial/expire-data/) on the `stored` field so that Mongo automatically deletes any expired data.
