### PR TITLE
Adding MongoDB TTL index

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -184,9 +184,15 @@ internals.Connection.prototype.getCollection = function (name, callback) {
         }
 
         // Found
+        collection.ensureIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }, function (err) {
 
-        self.collections[name] = collection;
-        return callback(null, collection);
+            if (err) {
+                return callback(err);
+            }
+
+            self.collections[name] = collection;
+            return callback(null, collection);
+        });
     });
 };
 
@@ -261,11 +267,14 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
             return callback(err);
         }
 
+        var expiresAt = new Date();
+        expiresAt.setMilliseconds(expiresAt.getMilliseconds() + ttl);
         var record = {
             _id: key.id,
             value: stringifiedValue,
             stored: new Date(),
-            ttl: ttl
+            ttl: ttl,
+            expiresAt: expiresAt
         };
 
         var criteria = { _id: key.id };

--- a/test/index.js
+++ b/test/index.js
@@ -650,6 +650,37 @@ describe('Mongo', function () {
                 });
             });
         });
+
+        it('passes an error to the callback when ensureIndex fails', function (done) {
+
+            var options = {
+                partition: 'unit-testing',
+                host: '127.0.0.1',
+                port: 27017,
+                poolSize: 5
+            };
+            var mongo = new Mongo(options);
+
+            mongo.start(function () {
+
+                mongo.client.collection = function (item, callback) {
+
+                    return callback(null, {
+                        ensureIndex: function (fieldOrSpec, options, callback) {
+
+                            return callback(new Error('test'));
+                        }
+                    });
+                };
+
+                mongo.getCollection('testcollection', function (err, result) {
+
+                    expect(err).to.exist();
+                    expect(result).to.not.exist();
+                    done();
+                });
+            });
+        });
     });
 
     describe('get()', function () {


### PR DESCRIPTION
I have same suggestion as https://github.com/hapijs/catbox-mongodb/pull/5

ensureIndex is called only once per process life-time in this implementation. 

As described here http://docs.mongodb.org/manual/tutorial/expire-data/ , every document requires expire date (I created expireAt field), so individual items can have individual times. 

Its my first day with Hapi, so hope its ok. I will need some assistance with code coverage though. It makes sense to test err incase it drops connection or something, but not sure how to write test for it.
