### PR TITLE
Value conversion by MongoDB driver instead of JSON

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -226,16 +226,8 @@ internals.Connection.prototype.get = function (key, callback) {
                 return callback(new Error('Incorrect record structure'));
             }
 
-            var value = null;
-            try {
-                value = JSON.parse(record.value);
-            }
-            catch (err) {
-                return callback(new Error('Bad value content'));
-            }
-
             var envelope = {
-                item: value,
+                item: record.value,
                 stored: record.stored.getTime(),
                 ttl: record.ttl
             };
@@ -258,20 +250,11 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
             return callback(err);
         }
 
-        var stringifiedValue = null;
-
-        try {
-            stringifiedValue = JSON.stringify(value);
-        }
-        catch (err) {
-            return callback(err);
-        }
-
         var expiresAt = new Date();
         expiresAt.setMilliseconds(expiresAt.getMilliseconds() + ttl);
         var record = {
             _id: key.id,
-            value: stringifiedValue,
+            value: value,
             stored: new Date(),
             ttl: ttl,
             expiresAt: expiresAt

--- a/test/index.js
+++ b/test/index.js
@@ -76,7 +76,7 @@ describe('Mongo', function () {
         });
     });
 
-    it('gets an item after settig it', function (done) {
+    it('gets an item after setting it', function (done) {
 
         var client = new Catbox.Client(Mongo);
         client.start(function (err) {
@@ -95,6 +95,34 @@ describe('Mongo', function () {
         });
     });
 
+    it('sets/gets following JS data types: Object, Array, Number, String, Date, RegExp', function (done) {
+
+        var client = new Catbox.Client(Mongo);
+        client.start(function (err) {
+
+            var key = { id: 'x', segment: 'test' };
+            var value = {
+                object: { a: 'b'},
+                array: [1, 2, 3],
+                number: 5.85,
+                string: 'hapi',
+                date: new Date('2014-03-07'),
+                regexp: /[a-zA-Z]+/
+            };
+
+            client.set(key, value, 500, function (err) {
+
+                expect(err).to.not.exist();
+                client.get(key, function (err, result) {
+
+                    expect(err).to.equal(null);
+                    expect(result.item).to.deep.equal(value);
+                    done();
+                });
+            });
+        });
+    });
+
     it('fails setting an item circular references', function (done) {
 
         var client = new Catbox.Client(Mongo);
@@ -105,7 +133,7 @@ describe('Mongo', function () {
             value.b = value;
             client.set(key, value, 10, function (err) {
 
-                expect(err.message).to.equal('Converting circular structure to JSON');
+                expect(err).to.exist();
                 done();
             });
         });
@@ -844,37 +872,6 @@ describe('Mongo', function () {
             });
         });
 
-        it('passes an error to the callback when there is an issue parsing the record value', function (done) {
-
-            var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27018,
-                poolSize: 5
-            };
-            var key = {
-                id: 'testerr',
-                segment: 'testerr'
-            };
-            var mongo = new Mongo(options);
-            mongo.client = true;
-            mongo.isConnected = true;
-
-            mongo.collections.testerr = {
-                findOne: function (item, callback) {
-
-                    return callback(null, { value: 'test', stored: true });
-                }
-            };
-
-            mongo.get(key, function (err, result) {
-
-                expect(err).to.exist();
-                expect(err.message).to.equal('Bad value content');
-                expect(result).to.not.exist();
-                done();
-            });
-        });
     });
 
     describe('set()', function () {


### PR DESCRIPTION
Is there good reason to use JSON.stringify?

I see advantages in using MongoDB driver conversion. 

It handles more data types, here is the conversion list [MongoDB driver docs](http://mongodb.github.io/node-mongodb-native/api-articles/nodekoarticle1.html?highlight=error%20object). Only some have direct conversion to/from JS objects, but some of them are very handy, like dates or regexps. Next step could be to add some automatic casting for buffers to binary type.

Also it should perform faster. MongoDB reads BSON from drive (or memory) and directly sends this BSON to client and mongo driver build JS objects. Parsing BSON should be faster (assuming good implementation), but I do not have proof for that :-).

Maybe I don't see some obvious reason, why its bad idea. Only issue I can think of at the moment is that if someone use catbox with mongodb  and than switch to other backend (like redis) it will throw errors on some data types that MongoDB handled, which might be unexpected.

Thank you for any feedback.
