### PR TITLE
Using _id field for item key

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -203,7 +203,7 @@ internals.Connection.prototype.get = function (key, callback) {
             return callback(err);
         }
 
-        var criteria = { key: key.id };
+        var criteria = { _id: key.id };
         collection.findOne(criteria, function (err, record) {
 
             if (err) {
@@ -262,13 +262,13 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
         }
 
         var record = {
-            key: key.id,
+            _id: key.id,
             value: stringifiedValue,
             stored: new Date(),
             ttl: ttl
         };
 
-        var criteria = { key: key.id };
+        var criteria = { _id: key.id };
         collection.update(criteria, record, { upsert: true, safe: true }, function (err, count) {
 
             if (err) {
@@ -293,7 +293,7 @@ internals.Connection.prototype.drop = function (key, callback) {
             return callback(err);
         }
 
-        var criteria = { key: key.id };
+        var criteria = { _id: key.id };
         collection.remove(criteria, { safe: true }, function (err, count) {
 
             if (err) {


### PR DESCRIPTION
In current implementation, _key_ field is used to store key. There is no index created though. 

I suggest to not create index for the _key_ field, but use __id_ instead. __id_ can be any type other than array ([MongoDoc](http://docs.mongodb.org/manual/core/document/#the-id-field)) and is automatically indexed with unique index which is exactly what we need here. 

Result is significantly better performance and it also saves some storage.
