### PR TITLE
new mongodb library support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,5 @@ Lead Maintainer: [Jarda Kotesovec](https://github.com/jardakotesovec)
 
 ### Options
 
-- `host` - the MongoDB server hostname. Defaults to `'127.0.0.1'`.
-- `port` - the MongoDB server port. Defaults to `27017`.
-- `username` - when the mongo server requires authentication. Defaults to no authentication.
-- `password` - the authentication password when `username` is configured.
-- `poolSize` - number of connections. Defaults to `5`.
+- `uri` - the [MongoDB URI](https://docs.mongodb.org/v3.0/reference/connection-string/). Defaults to `'mongodb://127.0.0.1:27017/?maxPoolSize=5'`.
 - `partition` - the MongoDB server database.
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var MongoDB = require('mongodb');
 var Hoek = require('hoek');
+var url = require('url');
 
 
 // Declare internals
@@ -10,9 +11,7 @@ var internals = {};
 
 
 internals.defaults = {
-    host: '127.0.0.1',
-    port: 27017,
-    poolSize: 5
+    uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5'
 };
 
 
@@ -33,7 +32,12 @@ exports = module.exports = internals.Connection = function (options) {
     Hoek.assert(options.partition.length < 64, 'Cache partition must be less than 64 bytes when using MongoDB');
 
     this.settings = Hoek.applyToDefaults(internals.defaults, options);
-    this.client = null;
+
+    // inserting the partition to the MongoDB URI
+    this.settings.uri = url.format(Hoek.applyToDefaults(url.parse(this.settings.uri), { pathname: this.settings.partition }));
+
+    this.db = null;
+    this.isConnectionStarted = false;
     this.isConnected = false;
     this.collections = {};
     this.startPending = null;           // Set to an array of callbacks if start pending
@@ -73,46 +77,32 @@ internals.Connection.prototype.start = function (callback) {
         self.startPending = null;
     };
 
-    // Create client
-
-    var server = new MongoDB.Server(this.settings.host, this.settings.port, { auto_reconnect: true, poolSize: this.settings.poolSize });
-    this.client = new MongoDB.Db(this.settings.partition, server, { safe: true });
+    // Connection started flag
+    this.isConnectionStarted = true;
 
     // Open connection
 
-    this.client.open(function (err, client) {
+    MongoDB.MongoClient.connect(this.settings.uri, function (err, db) {
 
         if (err) {
-            return connected(new Error('Failed opening connection'));
+            return connected(new Error('Failed opening connection:' + JSON.stringify(err)));
         }
 
-        // Authenticate
+        self.db = db;
 
-        if (self.settings.username) {
-            self.client.authenticate(self.settings.username, self.settings.password, function (err) {
-
-                if (err) {
-                    self.stop();
-                    return connected(new Error('Database authentication error: ' + JSON.stringify(err)));
-                }
-
-                return connected();
-            });
-        }
-        else {
-            return connected();
-        }
+        return connected();
     });
 };
 
 
 internals.Connection.prototype.stop = function () {
 
-    if (this.client) {
-        this.client.close();
-        this.client = null;
+    if (this.db) {
+        this.db.close();
+        this.db = null;
         this.collections = {};
         this.isConnected = false;
+        this.isConnectionStarted = false;
     }
 };
 
@@ -173,14 +163,11 @@ internals.Connection.prototype.getCollection = function (name, callback) {
 
     // Fetch collection
 
-    this.client.collection(name, function (err, collection) {
+
+    this.db.collection(name, function (err, collection) {
 
         if (err) {
             return callback(err);
-        }
-
-        if (!collection) {
-            return callback(new Error('Received null collection object'));
         }
 
         // Found
@@ -199,7 +186,7 @@ internals.Connection.prototype.getCollection = function (name, callback) {
 
 internals.Connection.prototype.get = function (key, callback) {
 
-    if (!this.client) {
+    if (!this.isConnectionStarted) {
         return callback(new Error('Connection not started'));
     }
 
@@ -240,7 +227,7 @@ internals.Connection.prototype.get = function (key, callback) {
 
 internals.Connection.prototype.set = function (key, value, ttl, callback) {
 
-    if (!this.client) {
+    if (!this.isConnectionStarted) {
         return callback(new Error('Connection not started'));
     }
 
@@ -275,7 +262,7 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
 
 internals.Connection.prototype.drop = function (key, callback) {
 
-    if (!this.client) {
+    if (!this.isConnectionStarted) {
         return callback(new Error('Connection not started'));
     }
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "node": ">=0.10.40"
   },
   "dependencies": {
-    "mongodb": "1.x.x",
-    "hoek": "2.x.x"
+    "hoek": "2.x.x",
+    "mongodb": "2.x.x"
   },
   "devDependencies": {
     "catbox": "6.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -413,12 +413,10 @@ describe('Mongo', function () {
         it('returns an error when authentication fails', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5,
-                username: 'bob'
+                uri: 'mongodb://bob:password@127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
+
             var mongo = new Mongo(options);
 
             mongo.start(function (err) {
@@ -432,12 +430,8 @@ describe('Mongo', function () {
         it('connects with authentication', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5,
-                username: 'tester',
-                password: 'secret'
+                uri: 'mongodb://tester:secret@127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -451,10 +445,8 @@ describe('Mongo', function () {
         it('sets isReady to true when the connection succeeds', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -469,10 +461,8 @@ describe('Mongo', function () {
         it('calls any pending callbacks waiting for a start', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -494,11 +484,10 @@ describe('Mongo', function () {
         it('returns an error when the name is empty', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
+
             var mongo = new Mongo(options);
 
             var result = mongo.validateSegmentName('');
@@ -511,11 +500,10 @@ describe('Mongo', function () {
         it('returns an error when the name has a null character', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
+
             var mongo = new Mongo(options);
 
             var result = mongo.validateSegmentName('\0test');
@@ -527,11 +515,10 @@ describe('Mongo', function () {
         it('returns an error when the name starts with system.', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
+
             var mongo = new Mongo(options);
 
             var result = mongo.validateSegmentName('system.');
@@ -543,10 +530,8 @@ describe('Mongo', function () {
         it('returns an error when the name has a $ character', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -559,10 +544,8 @@ describe('Mongo', function () {
         it('returns an error when the name is too long', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -575,10 +558,8 @@ describe('Mongo', function () {
         it('returns null when the name is valid', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -594,10 +575,8 @@ describe('Mongo', function () {
         it('passes an error to the callback when the connection is closed', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -613,10 +592,8 @@ describe('Mongo', function () {
         it('passes a collection to the callback', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -634,10 +611,8 @@ describe('Mongo', function () {
         it('passes an error to the callback when there is an error getting the collection', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -652,46 +627,17 @@ describe('Mongo', function () {
             });
         });
 
-        it('passes an error to the callback when the collection is null', function (done) {
-
-            var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
-            };
-            var mongo = new Mongo(options);
-
-            mongo.start(function () {
-
-                mongo.client.collection = function (item, callback) {
-
-                    callback(null, null);
-                };
-
-                mongo.getCollection('testcollection', function (err, result) {
-
-                    expect(err).to.exist();
-                    expect(result).to.not.exist();
-                    expect(err.message).to.equal('Received null collection object');
-                    done();
-                });
-            });
-        });
-
         it('passes an error to the callback when ensureIndex fails', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
             mongo.start(function () {
 
-                mongo.client.collection = function (item, callback) {
+                mongo.db.collection = function (item, callback) {
 
                     return callback(null, {
                         ensureIndex: function (fieldOrSpec, options2, callback2) {
@@ -716,10 +662,8 @@ describe('Mongo', function () {
         it('passes an error to the callback when the connection is closed', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -735,10 +679,8 @@ describe('Mongo', function () {
         it('passes a null item to the callback when it doesn\'t exist', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -756,10 +698,8 @@ describe('Mongo', function () {
         it('is able to retrieve an object thats stored when connection is started', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var key = {
                 id: 'test',
@@ -783,13 +723,11 @@ describe('Mongo', function () {
             });
         });
 
-        it('passes an error to the callback when there is an error finding the item', function (done) {
+        it('passes an error to the callback when there is no item', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27018,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27018/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var key = {
                 id: 'test',
@@ -811,17 +749,15 @@ describe('Mongo', function () {
         it('passes an error to the callback when there is an error returned from getting an item', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27018,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var key = {
                 id: 'testerr',
                 segment: 'testerr'
             };
             var mongo = new Mongo(options);
-            mongo.client = true;
+            mongo.isConnectionStarted = true;
             mongo.isConnected = true;
 
             mongo.collections.testerr = {
@@ -843,17 +779,15 @@ describe('Mongo', function () {
         it('passes an error to the callback when there is an issue with the record structure', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27018,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var key = {
                 id: 'testerr',
                 segment: 'testerr'
             };
             var mongo = new Mongo(options);
-            mongo.client = true;
+            mongo.isConnectionStarted = true;
             mongo.isConnected = true;
 
             mongo.collections.testerr = {
@@ -879,10 +813,8 @@ describe('Mongo', function () {
         it('passes an error to the callback when the connection is closed', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -898,10 +830,8 @@ describe('Mongo', function () {
         it('doesn\'t return an error when the set succeeds', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -919,17 +849,15 @@ describe('Mongo', function () {
         it('passes an error to the callback when there is an error returned from setting an item', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27018,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var key = {
                 id: 'testerr',
                 segment: 'testerr'
             };
             var mongo = new Mongo(options);
-            mongo.client = true;
+            mongo.isConnectionStarted = true;
             mongo.isConnected = true;
 
             mongo.getCollection = function (item, callback) {
@@ -949,17 +877,15 @@ describe('Mongo', function () {
         it('passes an error to the callback when there is an error returned from calling update', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27018,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var key = {
                 id: 'testerr',
                 segment: 'testerr'
             };
             var mongo = new Mongo(options);
-            mongo.client = true;
+            mongo.isConnectionStarted = true;
             mongo.isConnected = true;
 
             mongo.getCollection = function (item, callback) {
@@ -987,10 +913,8 @@ describe('Mongo', function () {
         it('passes an error to the callback when the connection is closed', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -1006,10 +930,8 @@ describe('Mongo', function () {
         it('doesn\'t return an error when the drop succeeds', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27017,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var mongo = new Mongo(options);
 
@@ -1027,17 +949,15 @@ describe('Mongo', function () {
         it('passes an error to the callback when there is an error returned from dropping an item', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27018,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var key = {
                 id: 'testerr',
                 segment: 'testerr'
             };
             var mongo = new Mongo(options);
-            mongo.client = true;
+            mongo.isConnectionStarted = true;
             mongo.isConnected = true;
 
             mongo.getCollection = function (item, callback) {
@@ -1057,17 +977,15 @@ describe('Mongo', function () {
         it('passes an error to the callback when there is an error returned from calling remove', function (done) {
 
             var options = {
-                partition: 'unit-testing',
-                host: '127.0.0.1',
-                port: 27018,
-                poolSize: 5
+                uri: 'mongodb://127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
             };
             var key = {
                 id: 'testerr',
                 segment: 'testerr'
             };
             var mongo = new Mongo(options);
-            mongo.client = true;
+            mongo.isConnectionStarted = true;
             mongo.isConnected = true;
 
             mongo.getCollection = function (item, callback) {


### PR DESCRIPTION
Allows to provide MongoDB URI as configuration, which is a common practice nowadays.

Referencing:
https://github.com/hapijs/catbox-mongodb/issues/12

Test:

> passes an error to the callback when the collection is null

was removed, because `db.collection` now works differently.

Please, review, ready to adjust according to your comments.

Regards,
