### PR TITLE
Fixed issue with parsing connection string with replicaSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ config.json
 */*/._*
 coverage.*
 lib-cov
-
+.vscode

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,8 @@
 
 // Load modules
 
-const Url = require('url');
 const MongoDB = require('mongodb');
 const Hoek = require('hoek');
-
 
 
 // Declare internals
@@ -22,6 +20,17 @@ exports = module.exports = internals.Connection = function (options) {
 
     Hoek.assert(this instanceof internals.Connection, 'MongoDB cache client must be instantiated using new');
 
+    this.settings = this.getSettings(options);
+
+    this.db = null;
+    this.isConnectionStarted = false;
+    this.isConnected = false;
+    this.collections = {};
+    this.startPending = null;           // Set to an array of callbacks if start pending
+    return this;
+};
+
+internals.Connection.prototype.getSettings = function (options) {
     /*
      Database names:
 
@@ -34,19 +43,14 @@ exports = module.exports = internals.Connection = function (options) {
     Hoek.assert(options.partition !== 'admin' && options.partition !== 'local' && options.partition !== 'config', 'Cache partition name cannot be "admin", "local", or "config" when using MongoDB');
     Hoek.assert(options.partition.length < 64, 'Cache partition must be less than 64 bytes when using MongoDB');
 
-    this.settings = Hoek.applyToDefaults(internals.defaults, options);
+    // merge with defaults
+    const settings = Hoek.applyToDefaults(internals.defaults, options);
 
-    // inserting the partition to the MongoDB URI
-    this.settings.uri = Url.format(Hoek.applyToDefaults(Url.parse(this.settings.uri), { pathname: this.settings.partition }));
+    // replace or add database
+    settings.uri = settings.uri.replace(/(mongodb:\/\/[^\/]*)([^\?]*)(.*)/,`$1/${settings.partition}$3`);
 
-    this.db = null;
-    this.isConnectionStarted = false;
-    this.isConnected = false;
-    this.collections = {};
-    this.startPending = null;           // Set to an array of callbacks if start pending
-    return this;
+    return settings;
 };
-
 
 internals.Connection.prototype.start = function (callback) {
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "catbox-mongodb",
   "description": "MongoDB adapter for catbox",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Eran Hammer <eran@hammer.io> (http://hueniverse.com)",
   "contributors": [
     "Wyatt Preul <wpreul@gmail.com> (http://jsgeek.com)"

--- a/test/index.js
+++ b/test/index.js
@@ -428,6 +428,130 @@ describe('Mongo', () => {
         done();
     });
 
+    describe('getSettings', () => {
+
+        it('parse single host connection string without db', (done) => {
+
+            const options = {
+                uri: 'mongodb://bob:password@127.0.0.1:27017',
+                partition: 'unit-testing'
+            };
+
+            const mongo = new Mongo(options);
+            const settings = mongo.getSettings(options);
+
+            expect(settings.uri).to.equal('mongodb://bob:password@127.0.0.1:27017/unit-testing');
+
+            done();
+        });
+
+        it('parse single host connection string without db with slash', (done) => {
+
+            const options = {
+                uri: 'mongodb://bob:password@127.0.0.1:27017/',
+                partition: 'unit-testing'
+            };
+
+            const mongo = new Mongo(options);
+            const settings = mongo.getSettings(options);
+
+            expect(settings.uri).to.equal('mongodb://bob:password@127.0.0.1:27017/unit-testing');
+
+            done();
+        });
+
+        it('parse single host connection string with credentials', (done) => {
+
+            const options = {
+                uri: 'mongodb://bob:password@127.0.0.1:27017/?maxPoolSize=5',
+                partition: 'unit-testing'
+            };
+
+            const mongo = new Mongo(options);
+            const settings = mongo.getSettings(options);
+
+            expect(settings.uri).to.equal('mongodb://bob:password@127.0.0.1:27017/unit-testing?maxPoolSize=5');
+
+            done();
+        });
+
+        it('parse single host connection string without credentials', (done) => {
+
+            const options = {
+                uri: 'mongodb://127.0.0.1:27017/test?maxPoolSize=5',
+                partition: 'unit-testing'
+            };
+
+            const mongo = new Mongo(options);
+            const settings = mongo.getSettings(options);
+
+            expect(settings.uri).to.equal('mongodb://127.0.0.1:27017/unit-testing?maxPoolSize=5');
+
+            done();
+        });
+
+        it('parse replica set in connection string without database', (done) => {
+
+            const options = {
+                uri: 'mongodb://bob:password@127.0.0.1:27017,127.0.0.2:27017,127.0.0.3:27017',
+                partition: 'unit-testing'
+            };
+
+            const mongo = new Mongo(options);
+            const settings = mongo.getSettings(options);
+
+            expect(settings.uri).to.equal('mongodb://bob:password@127.0.0.1:27017,127.0.0.2:27017,127.0.0.3:27017/unit-testing');
+
+            done();
+        });
+
+        it('parse replica set in connection string without database 2', (done) => {
+
+            const options = {
+                uri: 'mongodb://bob:password@127.0.0.1:27017,127.0.0.2:27017,127.0.0.3:27017/',
+                partition: 'unit-testing'
+            };
+
+            const mongo = new Mongo(options);
+            const settings = mongo.getSettings(options);
+
+            expect(settings.uri).to.equal('mongodb://bob:password@127.0.0.1:27017,127.0.0.2:27017,127.0.0.3:27017/unit-testing');
+
+            done();
+        });
+
+        it('parse replica set in connection string with database', (done) => {
+
+            const options = {
+                uri: 'mongodb://bob:password@127.0.0.1:27017,127.0.0.2:27017,127.0.0.3:27017/test',
+                partition: 'unit-testing'
+            };
+
+            const mongo = new Mongo(options);
+            const settings = mongo.getSettings(options);
+
+            expect(settings.uri).to.equal('mongodb://bob:password@127.0.0.1:27017,127.0.0.2:27017,127.0.0.3:27017/unit-testing');
+
+            done();
+        });
+
+        it('parse replica set in connection string', (done) => {
+
+            const options = {
+                uri: 'mongodb://bob:password@127.0.0.1:27017,127.0.0.2:27017,127.0.0.3:27017/?maxPoolSize=5&replicaSet=rs',
+                partition: 'unit-testing'
+            };
+
+            const mongo = new Mongo(options);
+            const settings = mongo.getSettings(options);
+
+            expect(settings.uri).to.equal('mongodb://bob:password@127.0.0.1:27017,127.0.0.2:27017,127.0.0.3:27017/unit-testing?maxPoolSize=5&replicaSet=rs');
+
+            done();
+        });
+
+    });
+
     describe('start()', () => {
 
         it('returns an error when authentication fails', (done) => {


### PR DESCRIPTION
**Issue**

In case if MongoDb connection string contains replica set, parsing URI returns an unexpected result. As result, the hosts list will be truncated and contain only the first node.

**Example**

```
this.settings.uri = 'mongodb://bob:password@127.0.0.1:27017,127.0.0.2:27017,127.0.0.3:27017/?maxPoolSize=5&replicaSet=rs';

this.settings.uri = Url.format(Hoek.applyToDefaults(Url.parse(this.settings.uri), { pathname: this.settings.partition }));

// this.settings.uri === 'mongodb://bob:password@127.0.0.1:27017/unit-testing?maxPoolSize=5&replicaSet=rs'
```

This issue relates to the way how `Url.parse` is parsing the urlString. It doesn't parse replica set correctly.