### PR TITLE
Update to catbox 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ config.json
 coverage.*
 lib-cov
 .vscode
+
+# ignore NPM's package-lock.json
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
+  - "8"
+  - "9"
+  - "node"
 
 services:
   - mongodb

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@
 
 const MongoDB = require('mongodb');
 const Hoek = require('hoek');
+const Boom = require('boom');
 
 
 // Declare internals
@@ -16,273 +17,207 @@ internals.defaults = {
 };
 
 
-exports = module.exports = internals.Connection = function (options) {
+exports = module.exports = internals.Connection = class {
 
-    Hoek.assert(this instanceof internals.Connection, 'MongoDB cache client must be instantiated using new');
+    constructor(options) {
 
-    this.settings = this.getSettings(options);
+        Hoek.assert(this instanceof internals.Connection, 'MongoDB cache client must be instantiated using new');
 
-    this.db = null;
-    this.isConnectionStarted = false;
-    this.isConnected = false;
-    this.collections = {};
-    this.startPending = null;           // Set to an array of callbacks if start pending
-    return this;
-};
+        this.settings = this.getSettings(options);
 
-internals.Connection.prototype.getSettings = function (options) {
-    /*
-     Database names:
-
-     - empty string is not valid
-     - cannot contain space, "*<>:|?
-     - limited to 64 bytes (after conversion to UTF-8)
-     - admin, local and config are reserved
-     */
-
-    Hoek.assert(options.partition !== 'admin' && options.partition !== 'local' && options.partition !== 'config', 'Cache partition name cannot be "admin", "local", or "config" when using MongoDB');
-    Hoek.assert(options.partition.length < 64, 'Cache partition must be less than 64 bytes when using MongoDB');
-
-    // merge with defaults
-    const settings = Hoek.applyToDefaults(internals.defaults, options);
-
-    // replace or add database
-    settings.uri = settings.uri.replace(/(mongodb:\/\/[^\/]*)([^\?]*)(.*)/,`$1/${settings.partition}$3`);
-
-    return settings;
-};
-
-internals.Connection.prototype.start = function (callback) {
-
-    // Check if already connected
-
-    if (this.isConnected) {
-        return callback();
-    }
-
-    // Check if start already pending
-
-    if (this.startPending) {
-        this.startPending.push(callback);
-        return;
-    }
-
-    // Set start pending state
-
-    this.startPending = [callback];
-
-    const connected = (err) => {
-
-        this.isConnected = !err;
-
-        for (let i = 0; i < this.startPending.length; ++i) {
-            this.startPending[i](err);
-        }
-
-        this.startPending = null;
-    };
-
-    // Connection started flag
-    this.isConnectionStarted = true;
-
-    // Open connection
-
-    MongoDB.MongoClient.connect(this.settings.uri, (err, db) => {
-
-        if (err) {
-            return connected(new Error('Failed opening connection:' + JSON.stringify(err)));
-        }
-
-        this.db = db;
-
-        return connected();
-    });
-};
-
-
-internals.Connection.prototype.stop = function () {
-
-    if (this.db) {
-        this.db.close();
         this.db = null;
-        this.collections = {};
-        this.isConnected = false;
         this.isConnectionStarted = false;
-    }
-};
-
-
-internals.Connection.prototype.isReady = function () {
-
-    return this.isConnected;
-};
-
-
-internals.Connection.prototype.validateSegmentName = function (name) {
-
-    /*
-     Collection names:
-
-     - empty string is not valid
-     - cannot contain "\0"
-     - avoid creating any collections with "system." prefix
-     - user created collections should not contain "$" in the name
-     - database name + collection name < 100 (actual 120)
-     */
-
-    if (!name) {
-        return new Error('Empty string');
+        this.connectionPromise = null;
+        this.isConnected = false;
+        this.collections = {};
+        return this;
     }
 
-    if (name.indexOf('\0') !== -1) {
-        return new Error('Includes null character');
+    getSettings(options) {
+        /*
+        Database names:
+
+        - empty string is not valid
+        - cannot contain space, "*<>:|?
+        - limited to 64 bytes (after conversion to UTF-8)
+        - admin, local and config are reserved
+        */
+
+        Hoek.assert(options.partition !== 'admin' && options.partition !== 'local' && options.partition !== 'config', 'Cache partition name cannot be "admin", "local", or "config" when using MongoDB');
+        Hoek.assert(options.partition.length < 64, 'Cache partition must be less than 64 bytes when using MongoDB');
+
+        // merge with defaults
+        const settings = Hoek.applyToDefaults(internals.defaults, options);
+
+        // replace or add database
+        settings.uri = settings.uri.replace(/(mongodb:\/\/[^\/]*)([^\?]*)(.*)/,`$1/${settings.partition}$3`);
+
+        return settings;
     }
 
-    if (name.indexOf('system.') === 0) {
-        return new Error('Begins with "system."');
-    }
+    async start() {
 
-    if (name.indexOf('$') !== -1) {
-        return new Error('Contains "$"');
-    }
-
-    if (name.length + this.settings.partition.length >= 100) {
-        return new Error('Segment and partition name lengths exceeds 100 characters');
-    }
-
-    return null;
-};
-
-
-internals.Connection.prototype.getCollection = function (name, callback) {
-
-    if (!this.isConnected) {
-        return callback(new Error('Connection not ready'));
-    }
-
-    if (this.collections[name]) {
-        return callback(null, this.collections[name]);
-    }
-
-    // Fetch collection
-
-
-    this.db.collection(name, (err, collection) => {
-
-        if (err) {
-            return callback(err);
+        // Check if already connected
+        if (this.isConnected) {
+            return;
         }
+
+        // Check if start already pending
+        if (this.connectionPromise) {
+            return this.connectionPromise;
+        }
+
+        // Connection started flag
+        this.isConnectionStarted = true;
+
+        try {
+            // Open connection
+            this.connectionPromise = MongoDB.MongoClient.connect(this.settings.uri);
+            this.db = await this.connectionPromise;
+            this.isConnected = true;
+        }
+        catch (err) {
+            // reset connection promise so that a failed connect won't block a new start
+            this.connectionPromise = null;
+            throw err;
+        }
+    }
+
+    stop() {
+
+        if (this.db) {
+            this.db.close();
+            this.db = null;
+            this.collections = {};
+            this.isConnected = false;
+            this.connectionPromise = null;
+            this.isConnectionStarted = false;
+        }
+    }
+
+    isReady() {
+
+        return this.isConnected;
+    }
+
+    validateSegmentName(name) {
+
+        /*
+        Collection names:
+
+        - empty string is not valid
+        - cannot contain "\0"
+        - avoid creating any collections with "system." prefix
+        - user created collections should not contain "$" in the name
+        - database name + collection name < 100 (actual 120)
+        */
+
+        if (!name) {
+            throw new Boom('Empty string');
+        }
+
+        if (name.indexOf('\0') !== -1) {
+            throw new Boom('Includes null character');
+        }
+
+        if (name.indexOf('system.') === 0) {
+            throw new Boom('Begins with "system."');
+        }
+
+        if (name.indexOf('$') !== -1) {
+            throw new Boom('Contains "$"');
+        }
+
+        if (name.length + this.settings.partition.length >= 100) {
+            throw new Boom('Segment and partition name lengths exceeds 100 characters');
+        }
+
+        return null;
+    }
+
+    async getCollection(name) {
+
+        if (!this.isConnected) {
+            throw new Boom('Connection not ready');
+        }
+
+        if (!name) {
+            throw new Boom('Collection name missing');
+        }
+
+        if (this.collections[name]) {
+            return this.collections[name];
+        }
+
+        // Fetch collection
+        const collection = await this.db.collection(name);
 
         // Found
-        collection.ensureIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }, (err) => {
+        await collection.ensureIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+        this.collections[name] = collection;
 
-            if (err) {
-                return callback(err);
-            }
-
-            this.collections[name] = collection;
-            return callback(null, collection);
-        });
-    });
-};
-
-
-internals.Connection.prototype.get = function (key, callback) {
-
-    if (!this.isConnectionStarted) {
-        return callback(new Error('Connection not started'));
+        return collection;
     }
 
-    this.getCollection(key.segment, (err, collection) => {
+    async get(key) {
 
-        if (err) {
-            return callback(err);
+        if (!this.isConnectionStarted) {
+            throw new Boom('Connection not started');
         }
 
+        const collection = await this.getCollection(key.segment);
         const criteria = { _id: key.id };
-        collection.findOne(criteria, (err, record) => {
+        const record = await collection.findOne(criteria);
 
-            if (err) {
-                return callback(err);
-            }
-
-            if (!record) {
-                return callback(null, null);
-            }
-
-            if (!record.value ||
-                !record.stored) {
-
-                return callback(new Error('Incorrect record structure'));
-            }
-
-            const envelope = {
-                item: record.value,
-                stored: record.stored.getTime(),
-                ttl: record.ttl
-            };
-
-            return callback(null, envelope);
-        });
-    });
-};
-
-
-internals.Connection.prototype.set = function (key, value, ttl, callback) {
-
-    if (!this.isConnectionStarted) {
-        return callback(new Error('Connection not started'));
-    }
-
-    this.getCollection(key.segment, (err, collection) => {
-
-        if (err) {
-            return callback(err);
+        if (!record) {
+            return null;
         }
 
+        if (!record.value || !record.stored) {
+            throw new Boom('Incorrect record structure');
+        }
+
+        const envelope = {
+            item: record.value,
+            stored: record.stored.getTime(),
+            ttl: record.ttl
+        };
+
+        return envelope;
+    }
+
+    async set(key, value, ttl) {
+
+        if (!this.isConnectionStarted) {
+            throw new Boom('Connection not started');
+        }
+
+        const collection = await this.getCollection(key.segment);
         const expiresAt = new Date();
         expiresAt.setMilliseconds(expiresAt.getMilliseconds() + ttl);
+
         const record = {
             _id: key.id,
-            value: value,
+            value,
             stored: new Date(),
-            ttl: ttl,
-            expiresAt: expiresAt
+            ttl,
+            expiresAt
         };
 
         const criteria = { _id: key.id };
-        collection.update(criteria, record, { upsert: true, safe: true }, (err, count) => {
 
-            if (err) {
-                return callback(err);
-            }
-
-            return callback();
-        });
-    });
-};
-
-
-internals.Connection.prototype.drop = function (key, callback) {
-
-    if (!this.isConnectionStarted) {
-        return callback(new Error('Connection not started'));
+        await collection.update(criteria, record, { upsert: true, safe: true });
     }
 
-    this.getCollection(key.segment, (err, collection) => {
+    async drop(key) {
 
-        if (err) {
-            return callback(err);
+        if (!this.isConnectionStarted) {
+            throw new Boom('Connection not started');
         }
 
+        const collection = await this.getCollection(key.segment);
+
         const criteria = { _id: key.id };
-        collection.remove(criteria, { safe: true }, (err, count) => {
-
-            if (err) {
-                return callback(err);
-            }
-
-            return callback();
-        });
-    });
+        await collection.remove(criteria, { safe: true });
+    }
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "3.0.1",
   "author": "Eran Hammer <eran@hammer.io> (http://hueniverse.com)",
   "contributors": [
-    "Wyatt Preul <wpreul@gmail.com> (http://jsgeek.com)"
+    "Wyatt Preul <wpreul@gmail.com> (http://jsgeek.com)",
+    "Marcus Poehls <marcus@futurestud.io> (https://futurestud.io)"
   ],
   "repository": "git://github.com/hapijs/catbox-mongodb",
   "main": "lib/index.js",
@@ -14,16 +15,17 @@
     "mongodb"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.9.0"
   },
   "dependencies": {
-    "hoek": "4.x.x",
+    "boom": "7.x.x",
+    "hoek": "5.x.x",
     "mongodb": "2.x.x"
   },
   "devDependencies": {
-    "catbox": "7.x.x",
-    "lab": "10.x.x",
-    "code": "2.x.x"
+    "catbox": "10.x.x",
+    "lab": "15.x.x",
+    "code": "5.x.x"
   },
   "scripts": {
     "test": "lab -r console -t 100 -a code -L",


### PR DESCRIPTION
This PR includes the following updates

- support for `catbox` 10
- refactor library to use an ES2015 `class`
- use `async/await` with promises from MongoDB's lib
- update tests to support changed library code
- bump dependencies to their latest versions
- requires Node.js `8.9.0` or later, defined in `package.json`
- update `.travis.yml` to test Node.js versions 8 and 9

Solves https://github.com/hapijs/catbox-mongodb/issues/27 (catbox 10 support)